### PR TITLE
on_websocket_message method shouldn't return an invalid message

### DIFF
--- a/discord/websocket.py
+++ b/discord/websocket.py
@@ -62,13 +62,15 @@ class WebSocket:
         if type(msg) is bytes:
             self.buffer.extend(msg)
 
-        # check if the last four bytes are equal to ZLIB_SUFFIX
-        if len(msg) < 4 or msg[-4:] != b'\x00\x00\xff\xff':
-            self.buffer = bytearray()
-            return
+            # check if the last four bytes are equal to ZLIB_SUFFIX
+            if len(msg) < 4 or msg[-4:] != b'\x00\x00\xff\xff':
+                self.buffer = bytearray()
+                return
 
-        msg = self.decompress.decompress(self.buffer)
-        self.buffer = bytearray()
+            msg = self.decompress.decompress(self.buffer)
+            self.buffer = bytearray()
+
+            return msg.decode('utf-8')
 
         return msg.decode('utf-8')
 


### PR DESCRIPTION
In the on_websocket_message method an invalid decoded message is returned when it clearly should not! if the zlib suffix doesn't match then it is not a valid message and it cannot be decoded without being decompressed!