### PR TITLE
__lt__ should return NotImplemented instead of raising NotImplementedError

### DIFF
--- a/discord/types/snowflake.py
+++ b/discord/types/snowflake.py
@@ -23,7 +23,7 @@ class Snowflake(BaseModel):
             return self.id < int(other)
         if isinstance(other, Snowflake):
             return self.id < other.id
-        raise NotImplementedError
+        return NotImplemented
 
     def __le__(self, other: object):
         return self.__eq__(other) or self.__lt__(other)


### PR DESCRIPTION
Reference https://docs.python.org/3/library/constants.html#NotImplemented

> A special value which should be returned by the binary special methods (e.g. __eq__(), __lt__(), __add__(), __rsub__(), etc.) to indicate that the operation is not implemented with respect to the other type; may be returned by the in-place binary special methods (e.g. __imul__(), __iand__(), etc.) for the same purpose. It should not be evaluated in a boolean context. NotImplemented is the sole instance of the [types.NotImplementedType](https://docs.python.org/3/library/types.html#types.NotImplementedType) type.

and...

>  When a binary (or in-place) method returns `NotImplemented` the interpreter will try the reflected operation on the other type (or some other fallback, depending on the operator). If all attempts return `NotImplemented`, the interpreter will raise an appropriate exception. Incorrectly returning `NotImplemented` will result in a misleading error message or the `NotImplemented` value being returned to Python code.
See [Implementing the arithmetic operations](https://docs.python.org/3/library/numbers.html#implementing-the-arithmetic-operations) for examples.